### PR TITLE
Plat 1062 helm chart update

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -1,0 +1,47 @@
+name: "Helm chart CI"
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  HELM_CHART_PATH: './deploy/openfaas-cron-connector'
+  HELM_CHART_REPO_NAME: 'ratehub'
+  HELM_CHART_REPO_URL: 'cm://helm.ratehub.dev'
+
+jobs:
+  helm:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 'Checkout codebase'
+        uses: actions/checkout@v2
+
+      - name: 'Setup helm'
+        id: install
+        uses: azure/setup-helm@v1
+        with:
+          version: 'v3.5.2'
+
+      - name: Lint helm chart
+        run: |
+          helm lint "${HELM_CHART_PATH}"
+
+      - name: Install helm push
+        run: |
+          helm plugin install https://github.com/chartmuseum/helm-push
+
+      - name: Add helm.ratehub.dev
+        env:
+          HELM_REPO_USERNAME: ${{ secrets.RATEHUB_HELM_USER }}
+          HELM_REPO_PASSWORD: ${{ secrets.RATEHUB_HELM_PASS }}
+        run: |
+          helm repo add "${HELM_CHART_REPO_NAME}" "${HELM_CHART_REPO_URL}"
+
+      - name: Publish helm chart
+        if: github.ref == 'refs/heads/master'
+        env:
+          HELM_REPO_USERNAME: ${{ secrets.RATEHUB_HELM_USER }}
+          HELM_REPO_PASSWORD: ${{ secrets.RATEHUB_HELM_PASS }}
+        run: |
+          helm push "${HELM_CHART_PATH}" "${HELM_CHART_REPO_NAME}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 .idea
+tmp

--- a/deploy/openfaas-cron-connector/.helmignore
+++ b/deploy/openfaas-cron-connector/.helmignore
@@ -1,4 +1,3 @@
-
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.
@@ -15,6 +14,7 @@
 *.swp
 *.bak
 *.tmp
+*.orig
 *~
 # Various IDEs
 .project

--- a/deploy/openfaas-cron-connector/Chart.yaml
+++ b/deploy/openfaas-cron-connector/Chart.yaml
@@ -1,6 +1,25 @@
-
-apiVersion: v1
-appVersion: "1.0.2"
-description: A Helm chart for Ratehub's cron connector for OpenFaaS
+apiVersion: v2
 name: openfaas-cron-connector
-version: 1.0.0
+description: A Helm chart for OpenFaaS Cron-Connector
+icon: https://www.openfaas.com/images/openfaas/whale.png
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.1"

--- a/deploy/openfaas-cron-connector/README.md
+++ b/deploy/openfaas-cron-connector/README.md
@@ -1,0 +1,44 @@
+# openfaas-cron-connector
+
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+
+A Helm chart for OpenFaaS Cron-Connector
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| basicAuthSecrets.existingSecrets | bool | `true` |  |
+| basicAuthSecrets.nameOverride | string | `""` |  |
+| basicAuthSecrets.values.basic-auth-password | string | `""` |  |
+| basicAuthSecrets.values.basic-auth-user | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"nginx"` |  |
+| image.tag | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
+| linkerd.enabled | bool | `true` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext.fsGroup | int | `2000` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| securityContext.runAsUser | int | `1000` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| settings.connector_name | string | `"openfaas-cron-connector"` |  |
+| settings.faas_gateway | string | `"gateway:8080"` |  |
+| settings.gateway_ssl | bool | `false` |  |
+| settings.linkerd | string | `"enabled"` |  |
+| settings.timeout | int | `30000` |  |
+| tolerations | list | `[]` |  |
+

--- a/deploy/openfaas-cron-connector/templates/NOTES.txt
+++ b/deploy/openfaas-cron-connector/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Currently no Service or Ingress resources are used for this chart.

--- a/deploy/openfaas-cron-connector/templates/_helpers.tpl
+++ b/deploy/openfaas-cron-connector/templates/_helpers.tpl
@@ -1,10 +1,9 @@
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
 {{- define "openfaas-cron-connector.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
@@ -12,21 +11,71 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "openfaas-cron-connector.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "openfaas-cron-connector.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "openfaas-cron-connector.labels" -}}
+helm.sh/chart: {{ include "openfaas-cron-connector.chart" . }}
+{{ include "openfaas-cron-connector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "openfaas-cron-connector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openfaas-cron-connector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "openfaas-cron-connector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "openfaas-cron-connector.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Linkerd Annotations
+*/}}
+{{- define "openfaas-cron-connector.linkerdAnnotations" -}}
+{{- if .Values.linkerd.enabled -}}
+linkerd.io/inject: enabled
+{{- else -}}
+linkerd.io/inject: disabled
+{{- end -}}
+{{- end }}
+
+{{/*
+Basic-Auth Secret name
+*/}}
+{{- define "openfaas-cron-connector.basic-auth-secrets-name" -}}
+{{- $defaultSecretName := (printf "%s%s" .Release.Name "-basic-auth-secrets") -}}
+{{- default $defaultSecretName .Values.basicAuthSecrets.nameOverride | trimSuffix "-" -}}
 {{- end -}}

--- a/deploy/openfaas-cron-connector/templates/basic-auth-secret.yaml
+++ b/deploy/openfaas-cron-connector/templates/basic-auth-secret.yaml
@@ -1,0 +1,12 @@
+{{- if (not .Values.basicAuthSecrets.existingSecrets) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openfaas-cron-connector.basic-auth-secrets-name" . | quote }}
+  labels:
+{{ include "openfaas-cron-connector.labels" . | indent 4 }}
+data:
+  {{- range $key, $value := .Values.basicAuthSecrets.values }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end }}
+{{- end }}

--- a/deploy/openfaas-cron-connector/templates/deployment.yaml
+++ b/deploy/openfaas-cron-connector/templates/deployment.yaml
@@ -3,67 +3,86 @@ kind: Deployment
 metadata:
   name: {{ include "openfaas-cron-connector.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "openfaas-cron-connector.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "openfaas-cron-connector.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "openfaas-cron-connector.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "openfaas-cron-connector.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
-        linkerd.io/inject: '{{.Values.linkerd }}'
+      {{- include "openfaas-cron-connector.linkerdAnnotations" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
-        app.kubernetes.io/name: {{ include "openfaas-cron-connector.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "openfaas-cron-connector.selectorLabels" . | nindent 8 }}
     spec:
-    {{- with .Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-      volumes:
-        - name: auth
-          secret:
-            secretName: basic-auth
+      {{- end }}
+      serviceAccountName: {{ include "openfaas-cron-connector.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           env:
             - name: CONNECTOR_NAME
-              value: {{ .Values.connector_name | quote }}
+              value: {{ .Values.settings.connector_name | quote }}
             - name: FAAS_GATEWAY
-              value: {{ .Values.faas_gateway | quote }}
+              value: {{ .Values.settings.faas_gateway | quote }}
             - name: GATEWAY_SSL
-              value: {{ .Values.gateway_ssl | quote  }}
-              {{ if .Values.faas_gateway_user }}
+              value: {{ .Values.settings.gateway_ssl | quote  }}
+              {{ if .Values.settings.faas_gateway_user }}
             - name: FAAS_GATEWAY_USER
-              value: {{ .Values.faas_gateway_user | quote }}
+              value: {{ .Values.settings.faas_gateway_user | quote }}
               {{ end }}
-              {{ if .Values.faas_gateway_pass }}
+              {{ if .Values.settings.faas_gateway_pass }}
             - name: FAAS_GATEWAY_PASS
-              value: {{ .Values.faas_gateway_pass | quote }}
+              value: {{ .Values.settings.faas_gateway_pass | quote }}
               {{ end }}
             - name: TIMEOUT
-              value: {{ .Values.timeout | quote }}
-          volumeMounts:
-            - name: auth
-              readOnly: true
-              mountPath: "/var/secrets"
+              value: {{ .Values.settings.timeout | quote }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /var/secrets
+              name: auth
+              readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      volumes:
+        - name: auth
+          secret:
+            defaultMode: 420
+            secretName: {{ include "openfaas-cron-connector.basic-auth-secrets-name" . | quote }}

--- a/deploy/openfaas-cron-connector/templates/hpa.yaml
+++ b/deploy/openfaas-cron-connector/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "openfaas-cron-connector.fullname" . }}
+  labels:
+    {{- include "openfaas-cron-connector.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "openfaas-cron-connector.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/openfaas-cron-connector/templates/serviceaccount.yaml
+++ b/deploy/openfaas-cron-connector/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openfaas-cron-connector.serviceAccountName" . }}
+  labels:
+    {{- include "openfaas-cron-connector.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/openfaas-cron-connector/values.schema.json
+++ b/deploy/openfaas-cron-connector/values.schema.json
@@ -1,0 +1,150 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "affinity": {
+            "type": "object"
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "maxReplicas": {
+                    "type": "integer"
+                },
+                "minReplicas": {
+                    "type": "integer"
+                },
+                "targetCPUUtilizationPercentage": {
+                    "type": "integer"
+                }
+            }
+        },
+        "basicAuthSecrets": {
+            "type": "object",
+            "properties": {
+                "existingSecrets": {
+                    "type": "boolean"
+                },
+                "nameOverride": {
+                    "type": "string"
+                },
+                "values": {
+                    "type": "object",
+                    "properties": {
+                        "basic-auth-password": {
+                            "type": "string"
+                        },
+                        "basic-auth-user": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "linkerd": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "podAnnotations": {
+            "type": "object"
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "fsGroup": {
+                    "type": "integer"
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object"
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                },
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "settings": {
+            "type": "object",
+            "properties": {
+                "connector_name": {
+                    "type": "string"
+                },
+                "faas_gateway": {
+                    "type": "string"
+                },
+                "gateway_ssl": {
+                    "type": "boolean"
+                },
+                "linkerd": {
+                    "type": "string"
+                },
+                "timeout": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array"
+        }
+    }
+}

--- a/deploy/openfaas-cron-connector/values.yaml
+++ b/deploy/openfaas-cron-connector/values.yaml
@@ -20,6 +20,7 @@ settings:
   gateway_ssl: false
   linkerd: enabled
   timeout: 30000
+  ## Assuming faas_gateway_* are secrets you should use VSWH to manage them if you need them.
   #faas_gateway_user: admin
   #faas_gateway_pass: admin
 

--- a/deploy/openfaas-cron-connector/values.yaml
+++ b/deploy/openfaas-cron-connector/values.yaml
@@ -5,20 +5,62 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/platform-235214/openfaas-cron-connector
-  tag: 1.0.1
+  repository: nginx
   pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
 
-imagePullSecrets:
-  - name: gcr-pull-secret
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
 
-connector_name: openfaas-cron-connector
-faas_gateway: gateway:8080
-gateway_ssl: false
-linkerd: enabled
-#faas_gateway_user: admin
-#faas_gateway_pass: admin
-timeout: 30000
+settings:
+  connector_name: openfaas-cron-connector
+  faas_gateway: gateway:8080
+  gateway_ssl: false
+  linkerd: enabled
+  timeout: 30000
+  #faas_gateway_user: admin
+  #faas_gateway_pass: admin
+
+basicAuthSecrets:
+  existingSecrets: true
+  nameOverride: ''
+  values:
+    basic-auth-password: ''
+    basic-auth-user: ''
+
+linkerd:
+  enabled: true
+
+## The ServiceAccount is used for Vault integration.
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+## Uncomment and update the VSWH settings to inject secrets into pods.
+podAnnotations: {}
+  # vault.security.banzaicloud.io/vault-addr: "https://vault.default.svc.cluster.local.:8200"
+  # vault.security.banzaicloud.io/vault-tls-secret: "vault-tls"
+  # vault.security.banzaicloud.io/vault-path: kubernetes
+  # vault.security.banzaicloud.io/vault-role: 
+  # vault.security.banzaicloud.io/vault-skip-verify: "true" # Container is missing Trusted Mozilla roots too.
+
+podSecurityContext:
+  fsGroup: 2000
+
+securityContext:
+  # capabilities:
+  #   drop:
+  #   - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -31,6 +73,13 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
 

--- a/deploy/openfaas-cron-connector/values.yaml
+++ b/deploy/openfaas-cron-connector/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: nginx
+  repository: gcr.io/platform-235214/openfaas-cron-connector
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
Refactoring the Helm chart:
 - convert the chart to apiVersion v2
 - make the auth secret optionally generated by the chart
 - restructure the values file
 - improve security: serviceAccount, pod and container security contexts
 - add optional HPA
 - no service (it appears none is needed)
 - add chart ReadMe and json-schema